### PR TITLE
Fix module import

### DIFF
--- a/mdformat_pelican/plugin.py
+++ b/mdformat_pelican/plugin.py
@@ -131,17 +131,19 @@ RENDERERS: Mapping[str, Render] = {
 # https://github.com/gaige/mdformat-pelican/issues/3
 # So we're going to monkey-patch mdformat_gfm's link rendering.
 try:
-    import mdformat_gfm
+    from mdformat_gfm import plugin
 
     def _patch_gfm_link_renderer(node: RenderTreeNode, context: RenderContext) -> str:
         """Patched link renderer that replaces pelican placeholders in link's href."""
-        if any((bad_placeholder in node.attrs["href"]) for bad_placeholder in PLACEHOLDERS):
+        if any(
+            (bad_placeholder in node.attrs["href"]) for bad_placeholder in PLACEHOLDERS
+        ):
             node.attrs["href"] = replace_pelican_placeholdlers(node.attrs["href"])
         # Use the original renderer.
-        return mdformat_gfm.plugin._link_renderer(node, context)
+        return plugin._link_renderer(node, context)
 
     # Use our patched renderer instead of mdfomat_gfm's.
-    mdformat_gfm.plugin.RENDERERS["link"] = _patch_gfm_link_renderer
+    plugin.RENDERERS["link"] = _patch_gfm_link_renderer
 
 # Register the link renderer the usual way if the gfm plugin is not installed.
 except ImportError:


### PR DESCRIPTION
In some circumstances, the patch introduced in #3 and #4 will fail with the following error:
```pytb
Traceback (most recent call last):
  File "/home/runner/work/workflows/workflows/.venv/bin/mdformat", line 5, in <module>
    from mdformat.__main__ import run
  File "/home/runner/work/workflows/workflows/.venv/lib/python3.12/site-packages/mdformat/__init__.py", line 4, in <module>
    from mdformat._api import file, text
  File "/home/runner/work/workflows/workflows/.venv/lib/python3.12/site-packages/mdformat/_api.py", line 10, in <module>
    from mdformat._util import EMPTY_MAP, NULL_CTX, build_mdit, detect_newline_type
  File "/home/runner/work/workflows/workflows/.venv/lib/python3.12/site-packages/mdformat/_util.py", line 12, in <module>
    import mdformat.plugins
  File "/home/runner/work/workflows/workflows/.venv/lib/python3.12/site-packages/mdformat/plugins.py", line 60, in <module>
    PARSER_EXTENSIONS: Mapping[str, ParserExtensionInterface] = _load_parser_extensions()
                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/workflows/workflows/.venv/lib/python3.12/site-packages/mdformat/plugins.py", line 57, in _load_parser_extensions
    return {ep.name: ep.load() for ep in parser_extension_entrypoints}
                     ^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/importlib/metadata/__init__.py", line 205, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/workflows/workflows/.venv/lib/python3.12/site-packages/mdformat_pelican/__init__.py", line 3, in <module>
    from .plugin import RENDERERS, update_mdit  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/workflows/workflows/.venv/lib/python3.12/site-packages/mdformat_pelican/plugin.py", line 144, in <module>
    mdformat_gfm.plugin.RENDERERS["link"] = _patch_gfm_link_renderer
    ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'mdformat_gfm' has no attribute 'plugin'
```
(Source: https://github.com/kdeldycke/workflows/actions/runs/10520430679/job/29149370480#step:9:15 )

This is a simple patch to fix this issue by being mode specific about the import.