### PR TITLE
Fix compatibility with `mdformat 1.0.0`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -49,9 +49,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 
@@ -68,9 +68,9 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Upgrade Pip
@@ -102,7 +102,7 @@ jobs:
       id-token: write
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: python-package-distributions
           path: dist/
@@ -123,12 +123,12 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: python-package-distributions
           path: dist/
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        uses: sigstore/gh-action-sigstore-python@v3.0.1
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.12'  # 3.12 and possibly lower will fail flake8
+        python-version: '3.14'
     - uses: pre-commit/action@v3.0.1
 
   tests:
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.12"
+        python-version: "3.14"
 
     - name: Installation (deps and package)
       run: |
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Upgrade Pip
         run: python -m pip install --upgrade pip
       - name: Install Poetry

--- a/mdformat_pelican/__init__.py
+++ b/mdformat_pelican/__init__.py
@@ -2,4 +2,4 @@
 
 from .plugin import RENDERERS, update_mdit  # noqa: F401
 
-__version__ = "0.2.2"
+__version__ = "1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,7 @@ requires-python = ">= 3.10"
 requires = ["mdformat >= 1.0.0"]
 
 [tool.flit.metadata.requires-extra]
-test = [
-    "pytest~=6.0",
-    "coverage",
-    "pytest-cov",
-]
+test = ["pytest >= 8.0.0", "coverage", "pytest-cov"]
 dev = ["pre-commit"]
 
 [tool.flit.entrypoints."mdformat.parser_extension"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,8 @@ classifiers = [
 ]
 keywords = "mdformat,markdown,markdown-it"
 
-requires-python=">=3.6"
-requires=["mdformat >=0.7.0,<0.8.0",
-            ]
+requires-python = ">= 3.10"
+requires = ["mdformat >= 1.0.0"]
 
 [tool.flit.metadata.requires-extra]
 test = [
@@ -52,7 +51,7 @@ profile = "black"
 line-length = 119
 
 [tool.commitizen]
-version = "0.2.2"
+version = "1.0.0"
 tag_format = "v$major.$minor.$patch$prerelease"
 version_files = [
 	"mdformat_pelican/__init__.py:__version__"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flit
 tox
 pytest
-mdformat >=0.7.0,<1.1.0
+mdformat >= 1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -11,24 +11,20 @@ deps = mdformat_gfm
 extras = test
 commands = pytest --cov --cov-append --cov-report=term-missing {posargs}
 
-# 3.12 is left out because of issues with importlib_metadata.entry_points
-[testenv:py{38,39,310,311}-pre-commit]
+[testenv:py{310,311,312,313,314}-pre-commit]
 extras = dev
 commands = pre-commit run {posargs}
 
-# 3.12 is left out because of issues with importlib_metadata.entry_points
-[testenv:py{38,39,310,311}-pre-commit-gfm]
+[testenv:py{310,311,312,313,314}-pre-commit-gfm]
 extras = dev
 deps = mdformat_gfm
 commands = pre-commit run {posargs}
 
-# 3.12 is left out because of issues with importlib_metadata.entry_points
-[testenv:py{38,39,310,311}-hook]
+[testenv:py{310,311,312,313,314}-hook]
 extras = dev
 commands = pre-commit run --config .pre-commit-test.yaml {posargs:--all-files --verbose --show-diff-on-failure}
 
-# 3.12 is left out because of issues with importlib_metadata.entry_points
-[testenv:py{38,39,310,311}-hook-gfm]
+[testenv:py{310,311,312,313,314}-hook-gfm]
 extras = dev
 deps = mdformat_gfm
 commands = pre-commit run --config .pre-commit-test.yaml {posargs:--all-files --verbose --show-diff-on-failure}

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py{38,39,310,311,312},py{38,39,310,311,312}-gfm
+envlist = py{310,311,312,313,314},py{310,311,312,313,314}-gfm
 isolated_build = True
 
-[testenv:py{38,39,310,311,312}]
+[testenv:py{310,311,312,313,314}]
 extras = test
 commands = pytest --cov --cov-append --cov-report=term-missing {posargs}
 
-[testenv:py{38,39,310,311,312}-gfm]
+[testenv:py{310,311,312,313,314}-gfm]
 deps = mdformat_gfm
 extras = test
 commands = pytest --cov --cov-append --cov-report=term-missing {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -11,23 +11,23 @@ deps = mdformat_gfm
 extras = test
 commands = pytest --cov --cov-append --cov-report=term-missing {posargs}
 
-# 3.12 is left out beause of issues with importlib_metadata.entry_points
+# 3.12 is left out because of issues with importlib_metadata.entry_points
 [testenv:py{38,39,310,311}-pre-commit]
 extras = dev
 commands = pre-commit run {posargs}
 
-# 3.12 is left out beause of issues with importlib_metadata.entry_points
+# 3.12 is left out because of issues with importlib_metadata.entry_points
 [testenv:py{38,39,310,311}-pre-commit-gfm]
 extras = dev
 deps = mdformat_gfm
 commands = pre-commit run {posargs}
 
-# 3.12 is left out beause of issues with importlib_metadata.entry_points
+# 3.12 is left out because of issues with importlib_metadata.entry_points
 [testenv:py{38,39,310,311}-hook]
 extras = dev
 commands = pre-commit run --config .pre-commit-test.yaml {posargs:--all-files --verbose --show-diff-on-failure}
 
-# 3.12 is left out beause of issues with importlib_metadata.entry_points
+# 3.12 is left out because of issues with importlib_metadata.entry_points
 [testenv:py{38,39,310,311}-hook-gfm]
 extras = dev
 deps = mdformat_gfm


### PR DESCRIPTION
I juste realized that the new 0.2.2 release does not fix the compatibility with `mdformat 1.0.0`.

Here is the proof:
```shell-session
$ uv pip install "mdformat == 1.0.0" "mdformat-pelican == 0.2.2"                                                                                              
  × No solution found when resolving dependencies:
  ╰─▶ Because mdformat-pelican==0.2.2 depends on mdformat>=0.7.0,<0.8.0 and you require mdformat==1.0.0, we can conclude that your requirements and mdformat-pelican==0.2.2 are incompatible.
      And because you require mdformat-pelican==0.2.2, we can conclude that your requirements are unsatisfiable.
```

This PR is an attempt to fix this.

But while browsing around the code of `mdformat-pelican`, I couldn't help but try to update things left and right:
- Bump minimal Python to 3.10 (to align it with `mdformat 1.0.0` owns requirement)
- Add tests on Python 3.13 and 3.14
- Remove tests on Python 3.8 and 3.9
- Bump all GitHub workflow actions
- Fix Pytest issue by bumping to 8.0.0
- Fix some typos
- Bump plugin version to 1.0.0

That's why I made this PR a draft so I can validate these changes against the project's CI.

Sorry if this PR feels a bit bigger in scope than simply fixing `mdformat 1.0.0` compatibility. So please tell me if some changes are too aggressive in which case I'll be happy to scale down my propositions.

