### PR TITLE
Fix link renderer conflict with `mdformat-gfm` 1.0.0 and other plugins

### DIFF
--- a/mdformat_pelican/__init__.py
+++ b/mdformat_pelican/__init__.py
@@ -1,5 +1,5 @@
 """An mdformat plugin for pelican markdown items"""
 
-from .plugin import RENDERERS, update_mdit  # noqa: F401
+from .plugin import POSTPROCESSORS, RENDERERS, update_mdit  # noqa: F401
 
 __version__ = "0.2.2"

--- a/mdformat_pelican/plugin.py
+++ b/mdformat_pelican/plugin.py
@@ -1,10 +1,10 @@
-from typing import Mapping
+from typing import Any, Mapping
 
 from markdown_it import MarkdownIt
 from markdown_it.rules_block import StateBlock
 from mdformat import renderer
 from mdformat.renderer import RenderContext, RenderTreeNode
-from mdformat.renderer.typing import Render
+from mdformat.renderer.typing import Postprocess, Render
 
 
 def update_mdit(mdit: MarkdownIt) -> None:
@@ -115,9 +115,18 @@ def _pelican_image_renderer(node: RenderTreeNode, context: RenderContext) -> str
     return renderer.DEFAULT_RENDERERS.get("image")(node, context)
 
 
-def _pelican_link_open_renderer(node: RenderTreeNode, context: RenderContext) -> str:
-    node.attrs["href"] = replace_pelican_placeholdlers(node.attrs["href"])
-    return renderer.DEFAULT_RENDERERS.get("link")(node, context)
+# Replace Pelican placeholders in already-rendered link output, after the link
+# renderer has produced the final `[text](url)` string. Using a postprocessor
+# instead of overriding the link renderer avoids conflicts with other plugins
+# that also register a link renderer (e.g. mdformat-recover-urls), since
+# postprocessors are collaborative while only the first registered renderer
+# wins.
+def _pelican_link_postprocessor(
+    text: str,
+    node: RenderTreeNode,
+    context: Any,
+) -> str:
+    return replace_pelican_placeholdlers(text)
 
 
 RENDERERS: Mapping[str, Render] = {
@@ -125,24 +134,6 @@ RENDERERS: Mapping[str, Render] = {
     "image": _pelican_image_renderer,
 }
 
-
-# XXX mdformat-pelican and mdformat-gfm plugins are not compatible. See:
-# https://github.com/hukkin/mdformat-gfm/issues/38
-# https://github.com/gaige/mdformat-pelican/issues/3
-# So we're going to monkey-patch mdformat_gfm's link rendering.
-try:
-    from mdformat_gfm import plugin
-
-    def _patch_gfm_link_renderer(node: RenderTreeNode, context: RenderContext) -> str:
-        """Patched link renderer that replaces pelican placeholders in link's href."""
-        if any((bad_placeholder in node.attrs["href"]) for bad_placeholder in PLACEHOLDERS):
-            node.attrs["href"] = replace_pelican_placeholdlers(node.attrs["href"])
-        # Use the original renderer.
-        return plugin._link_renderer(node, context)
-
-    # Use our patched renderer instead of mdfomat_gfm's.
-    plugin.RENDERERS["link"] = _patch_gfm_link_renderer
-
-# Register the link renderer the usual way if the gfm plugin is not installed.
-except ImportError:
-    RENDERERS["link"] = _pelican_link_open_renderer
+POSTPROCESSORS: Mapping[str, Postprocess] = {
+    "link": _pelican_link_postprocessor,
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,16 +16,11 @@ classifiers = [
 ]
 keywords = "mdformat,markdown,markdown-it"
 
-requires-python=">=3.6"
-requires=["mdformat >=0.7.0,<0.8.0",
-            ]
+requires-python = ">= 3.10"
+requires = ["mdformat >= 1.0.0"]
 
 [tool.flit.metadata.requires-extra]
-test = [
-    "pytest~=6.0",
-    "coverage",
-    "pytest-cov",
-]
+test = ["pytest >= 8.0.0", "coverage", "pytest-cov"]
 dev = ["pre-commit"]
 
 [tool.flit.entrypoints."mdformat.parser_extension"]


### PR DESCRIPTION
This PR fix the compatibility with `mdformat-gfm` and other plugins.

It:
- Use a `postprocessor` for Pelican link placeholders to replaces the broken `RENDERERS["link"]` override with `POSTPROCESSORS["link"]`
- Bump `requires-python = ">= 3.10"` and `mdformat >= 1.0.0` to match the new plugin API

Follows up on:
- https://github.com/gaige/mdformat-pelican/commit/1c279652bb7f53517cfa2582463a78e5ef02973f
- https://github.com/gaige/mdformat-pelican/commit/ff5877d8a733a76fe60cce179f902b86fb69be03