### PR TITLE
ci: bump action versions, fix codeql triggers, refresh python matrix

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '42 12 * * 3'
 
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'  # 3.12 and possibly lower will fail flake8
     - uses: pre-commit/action@v3.0.1
@@ -22,14 +22,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: [ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -49,9 +49,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 
@@ -68,9 +68,9 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Upgrade Pip
@@ -80,7 +80,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -102,7 +102,7 @@ jobs:
       id-token: write
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -123,12 +123,12 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        uses: sigstore/gh-action-sigstore-python@v3
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/tox.ini
+++ b/tox.ini
@@ -1,34 +1,34 @@
 [tox]
-envlist = py{38,39,310,311,312},py{38,39,310,311,312}-gfm
+envlist = py{310,311,312,313,314},py{310,311,312,313,314}-gfm
 isolated_build = True
 
-[testenv:py{38,39,310,311,312}]
+[testenv:py{310,311,312,313,314}]
 extras = test
 commands = pytest --cov --cov-append --cov-report=term-missing {posargs}
 
-[testenv:py{38,39,310,311,312}-gfm]
+[testenv:py{310,311,312,313,314}-gfm]
 deps = mdformat_gfm
 extras = test
 commands = pytest --cov --cov-append --cov-report=term-missing {posargs}
 
 # 3.12 is left out beause of issues with importlib_metadata.entry_points
-[testenv:py{38,39,310,311}-pre-commit]
+[testenv:py{310,311}-pre-commit]
 extras = dev
 commands = pre-commit run {posargs}
 
 # 3.12 is left out beause of issues with importlib_metadata.entry_points
-[testenv:py{38,39,310,311}-pre-commit-gfm]
+[testenv:py{310,311}-pre-commit-gfm]
 extras = dev
 deps = mdformat_gfm
 commands = pre-commit run {posargs}
 
 # 3.12 is left out beause of issues with importlib_metadata.entry_points
-[testenv:py{38,39,310,311}-hook]
+[testenv:py{310,311}-hook]
 extras = dev
 commands = pre-commit run --config .pre-commit-test.yaml {posargs:--all-files --verbose --show-diff-on-failure}
 
 # 3.12 is left out beause of issues with importlib_metadata.entry_points
-[testenv:py{38,39,310,311}-hook-gfm]
+[testenv:py{310,311}-hook-gfm]
 extras = dev
 deps = mdformat_gfm
 commands = pre-commit run --config .pre-commit-test.yaml {posargs:--all-files --verbose --show-diff-on-failure}


### PR DESCRIPTION
- Update action pins to current majors: actions/checkout@v6, setup-python@v6, upload/download-artifact@v7, codeql-action@v4, sigstore/gh-action-sigstore-python@v3.
- Fix codeql-analysis.yml push/PR triggers from master to main so the workflow actually runs on this repo's default branch.
- tox.ini and tests.yml matrix: add 3.13 and 3.14, drop 3.8 and 3.9 (pyproject already requires >= 3.10). pre-commit/hook envs keep their existing 3.12+ exclusion.